### PR TITLE
Fix warning "Received `true` for a non-boolean attribute"

### DIFF
--- a/src/components/Base.js
+++ b/src/components/Base.js
@@ -1,9 +1,9 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-import { generateStyles } from "../helpers";
+import { stripBoolean, generateStyles } from "../helpers";
 
-const Base = element => styled(element)(generateStyles);
+const Base = element => styled(stripBoolean(element))(generateStyles);
 
 Base.propTypes = {
   // Positioning

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { css } from "styled-components";
 
 export const drawDebug = () => [
@@ -155,3 +156,6 @@ export const flex = ({
 
   return props;
 };
+
+// eslint-disable-next-line max-len
+export const stripBoolean = (Element) => ({ debug, fluid, fill, wrap, ...props }) => <Element {...props} />


### PR DESCRIPTION
Resolves https://github.com/garetmckinley/hedron/issues/101

What's been going on is essentially all boolean props (debug, fluid, fill, wrap) have been written directly to `<div>` itself, causing react to render it as e.g. `<div fluid=true>`. It is a know issue with styled components described here: https://www.styled-components.com/docs/faqs#why-am-i-getting-html-attribute-warnings

The workaround uses `stripBoolean` HoC function that manually takes away boolean props from the element passed as an argument.